### PR TITLE
reset in-memory notes when loading a new puzzle

### DIFF
--- a/xdplayer/__init__.py
+++ b/xdplayer/__init__.py
@@ -607,6 +607,7 @@ class CrosswordPlayer:
         self.crossword_paths.append(self.xd)
         self.xd.clear()
         self.xd.lastpos = 0
+        self.xd.notes = defaultdict(list)
         self.xd.replay_guesses()
 
     def status(self, s):


### PR DESCRIPTION
this fixes the issue where notes were duplicated when loading a puzzle for the 2nd+ time