### PR TITLE
Add a * to clues that have notes

### DIFF
--- a/xdplayer/__init__.py
+++ b/xdplayer/__init__.py
@@ -407,6 +407,14 @@ class Crossword:
                 self.clue_layout[dirnum] = y
                 dnw = len(dirnum)+2
                 maxw = max(min(w-clue_left-dnw-1, 40), 1)
+
+                # add a user coloured "*", for the most recent user
+                # who left a note
+                note = self.notes.get(dirnum, None)
+                if note:
+                    note_attr = self.get_user_attr(note[-1]['user'])
+                    clipdraw(scr, clue_top+y, w-4, "*", note_attr)
+
                 for j, line in enumerate(textwrap.wrap(clue.clue + f' [{guess}]', width=maxw)):
                     prefix = f'{dirnum}. ' if j == 0 else ' '*dnw
                     line = prefix + line + ' '*(maxw-len(line))


### PR DESCRIPTION
`*` is coloured based on the user_attr
for the user who most recently added a note.

![Screenshot from 2022-02-06 00-49-04](https://user-images.githubusercontent.com/7489659/152673817-e3c1d3ed-cc8e-41cf-b17a-c37252b2bf5a.png)
![Screenshot from 2022-02-06 00-49-22](https://user-images.githubusercontent.com/7489659/152673818-b4413d9c-4aec-4b3f-ad9e-658dabd94ed0.png)

Placement of `*` is relative to terminal width!

