### PR TITLE
reset statuses when switching to the next crossword

### DIFF
--- a/xdplayer/__init__.py
+++ b/xdplayer/__init__.py
@@ -681,6 +681,7 @@ class CrosswordPlayer:
         if k == '^L': scr.clear()
         if k == '^N':
             self.next_crossword()
+            self.statuses=[]
             scr.clear()
         if k == '^Y':
             if self.xd.curr_dirnum:


### PR DESCRIPTION
Since https://github.com/devottys/xdplayer/commit/3fc67a8fa2e88eaef4e8c0e85a1653e93e7906e9 the most recent status message stays on screen. This can be confusing when switching crosswords, and moving on from the status message's actual context.

This might not be the best place to do this! It might be preferable to move this to within `next_crossword()`? It also might be preferable to name a function (`reset_status`). I wanted to open a PR to discuss it.