### PR TITLE
[rebus] fix case where meta does not contain 'Rebus'

### DIFF
--- a/xdplayer/__init__.py
+++ b/xdplayer/__init__.py
@@ -132,7 +132,7 @@ class Crossword:
             k, v = line.split(':', maxsplit=1)
             self.meta[k.strip()] = v.strip()
 
-        rebus_soln = dict(r.split('=') for r in self.meta.get('Rebus', '').split(','))
+        rebus_soln = dict(r.split('=') for r in self.meta['Rebus'].split(',')) if 'Rebus' in self.meta else {}
 
         self.solution = [
             list(rebus_soln.get(ch, ch) for ch in line)


### PR DESCRIPTION
- dict(['']) results in an Exception in Python, which is why the
previous version was not working

- the Exception was ValueError: dictionary update sequence element #0 has length 0; 2 is required